### PR TITLE
Minimal change to update to bevy 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["gamedev", "bevy", "inputmap","actionmapping"]
 
 [dependencies]
 # bevy
-bevy = { version="0.2", features = ["serialize"]}
+bevy = { version="0.3", features = ["serialize"]}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ron = "0.6.2"

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -157,6 +157,7 @@ impl InputMap {
                         input_map.player_to_joystick_map.remove(&player_handle);
                     }
                 }
+                _ => ()
             }
         }
     }
@@ -174,7 +175,7 @@ impl InputMap {
                 let bevy_axis_type = InputMap::get_bevy_gamepad_axis_type_from_pad_axis(axis);
                 let bevy_axis = bevy::input::gamepad::GamepadAxis(bevy_gamepad, bevy_axis_type);
 
-                let signed_str = pad_axis.get(&bevy_axis).unwrap_or(0.);
+                let signed_str = pad_axis.get(bevy_axis).unwrap_or(0.);
 
                 if signed_str > 0. && is_positive || signed_str < 0. && !is_positive {
                     input_map.set_raw_action_strength(&v.to_string(), signed_str.abs());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ impl Plugin for InputMapPlugin {
             .add_event::<OnActionBegin>()
             .add_event::<OnActionProgress>()
             .add_event::<OnActionEnd>()
-            .add_system_to_stage(stage::EVENT_UPDATE, InputMap::action_event_producer.system())
+            .add_system_to_stage(stage::EVENT, InputMap::action_event_producer.system())
             // reset
             .add_system_to_stage(stage::PRE_UPDATE, InputMap::action_reset_system.system())
             // joystick


### PR DESCRIPTION
These are the minimal changes that I found to migrate to bevy 0.3.0

This does not handle the new GamepadEventType AxisChanged and ButtonChanged.


