### PR TITLE
Support enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ron = "0.6.2"
 
+[dev-dependencies]
+strum = { version = "0.20", features = ["derive"] }
+
 [[example]]
 name = "keyboard_mouse_with_code"
 path = "example/binding_in_code.rs"
@@ -35,3 +38,7 @@ path = "example/binding_gamepad_from_ron.rs"
 [[example]]
 name = "with_action_events"
 path = "example/example_action_events.rs"
+
+[[example]]
+name = "enum"
+path = "example/enum.rs"

--- a/example/enum.rs
+++ b/example/enum.rs
@@ -4,7 +4,6 @@ use bevy::app::Events;
 use bevy::ecs::ResMut;
 use kurinji::{EventPhase, Kurinji, KurinjiPlugin, MouseAxis, OnActionActive};
 use strum::{IntoStaticStr, EnumString};
-
 #[derive(IntoStaticStr, EnumString, PartialEq, Eq)]
 enum Action {
     JUMP,
@@ -19,7 +18,6 @@ enum Action {
     AimLeft,
     AimRight,
 }
-
 fn main() {
     println!("Kurinji Binding In Code Example");
     App::build()
@@ -116,11 +114,10 @@ fn action_system(
         app_exit_events.send(AppExit);
     }
 }
-
 fn action_active_events_system(
     action_active_event: Res<Events<OnActionActive>>,
 ) {
-    for value in  action_active_event.iter_current_update_events() {
+    for value in action_active_event.iter_current_update_events() {
         if value.action() == Some(Action::JUMP) {
             println!("Jumping...");
         }

--- a/example/enum.rs
+++ b/example/enum.rs
@@ -1,0 +1,143 @@
+use bevy::prelude::*;
+use bevy::app::AppExit;
+use bevy::app::Events;
+use bevy::ecs::ResMut;
+use kurinji::{EventPhase, Kurinji, KurinjiPlugin, MouseAxis, OnActionActive};
+use strum::{IntoStaticStr, EnumString};
+
+#[derive(IntoStaticStr, EnumString, PartialEq, Eq)]
+enum Action {
+    JUMP,
+    SHOOT,
+    MoveLeft,
+    MoveRight,
+    MoveForward,
+    MoveBackward,
+    QuitApp,
+    AimUp,
+    AimDown,
+    AimLeft,
+    AimRight,
+}
+
+fn main() {
+    println!("Kurinji Binding In Code Example");
+    App::build()
+        .add_plugins(DefaultPlugins)
+        // setup
+        .add_plugin(KurinjiPlugin::default())
+        .add_startup_system(setup.system())
+        .add_system(action_system.system())
+        .add_system(action_active_events_system.system())
+        .run();
+}
+fn setup(mut kurinji: ResMut<Kurinji>) {
+    kurinji
+        // keyboard
+        .bind_keyboard_pressed(KeyCode::Space, Action::JUMP)
+        .bind_keyboard_pressed(KeyCode::Return, Action::SHOOT)
+        .bind_keyboard_pressed(KeyCode::A, Action::MoveLeft)
+        .bind_keyboard_pressed(KeyCode::D, Action::MoveRight)
+        .bind_keyboard_pressed(KeyCode::W, Action::MoveForward)
+        .bind_keyboard_pressed(KeyCode::S, Action::MoveBackward)
+        .bind_keyboard_pressed(KeyCode::Escape, Action::QuitApp)
+        // mouse
+        .bind_mouse_button_pressed(MouseButton::Left, Action::SHOOT)
+        .bind_mouse_button_pressed(MouseButton::Right, Action::JUMP)
+        .bind_mouse_motion(MouseAxis::YNegative, Action::AimUp)
+        .bind_mouse_motion(MouseAxis::YPositive, Action::AimDown)
+        .bind_mouse_motion(MouseAxis::XNegative, Action::AimLeft)
+        .bind_mouse_motion(MouseAxis::XPositive, Action::AimRight)
+        // set event phase
+        .set_event_phase(Action::QuitApp, EventPhase::OnEnded)
+        .set_event_phase(Action::SHOOT, EventPhase::OnBegin);
+    println!("{}", kurinji.get_bindings_as_json().unwrap());
+}
+fn action_system(
+    kurinji: Res<Kurinji>,
+    mut app_exit_events: ResMut<Events<AppExit>>,
+) {
+    if kurinji.is_action_active(Action::JUMP) {
+        println!("Jumping...");
+    }
+    if kurinji.is_action_active(Action::SHOOT) {
+        println!("Bang");
+    }
+    if kurinji.is_action_active(Action::AimUp) {
+        println!(
+            "AIM_UP... [ strength: {}] ",
+            kurinji.get_action_strength(Action::AimUp)
+        );
+    }
+    if kurinji.is_action_active(Action::AimDown) {
+        println!(
+            "AIM_DOWN... [ strength: {}] ",
+            kurinji.get_action_strength(Action::AimDown)
+        );
+    }
+    if kurinji.is_action_active(Action::AimLeft) {
+        println!(
+            "AIM_LEFT... [ strength: {}] ",
+            kurinji.get_action_strength(Action::AimLeft)
+        );
+    }
+    if kurinji.is_action_active(Action::AimRight) {
+        println!(
+            "AIM_RIGHT... [ strength: {}] ",
+            kurinji.get_action_strength(Action::AimRight)
+        );
+    }
+    if kurinji.is_action_active(Action::MoveLeft) {
+        println!(
+            "MOVE_LEFT... [ strength: {}] ",
+            kurinji.get_action_strength(Action::MoveLeft)
+        );
+    }
+    if kurinji.is_action_active(Action::MoveRight) {
+        println!(
+            "MOVE_RIGHT... [ strength: {}] ",
+            kurinji.get_action_strength(Action::MoveRight)
+        );
+    }
+    if kurinji.is_action_active(Action::MoveForward) {
+        println!(
+            "MOVE_FORWARD... [ strength: {}] ",
+            kurinji.get_action_strength(Action::MoveForward)
+        );
+    }
+    if kurinji.is_action_active(Action::MoveBackward) {
+        println!(
+            "MOVE_BACKWARD... [ strength: {}] ",
+            kurinji.get_action_strength(Action::MoveBackward)
+        );
+    }
+    if kurinji.is_action_active(Action::QuitApp) {
+        println!("Quiting...");
+        app_exit_events.send(AppExit);
+    }
+}
+
+fn action_active_events_system(
+    action_active_event: Res<Events<OnActionActive>>,
+) {
+    for value in  action_active_event.iter_current_update_events() {
+        if value.action() == Some(Action::JUMP) {
+            println!("Jumping...");
+        }
+        if value.action() == Some(Action::SHOOT) {
+            println!("Bang");
+        }
+        if value.action() == Some(Action::AimUp) {
+            println!("AIM_UP... [ strength: {}] ", value.strength);
+        }
+        if value.action() == Some(Action::AimDown) {
+            println!("AIM_DOWN... [ strength: {}] ", value.strength);
+        }
+        if value.action() == Some(Action::AimLeft) {
+            println!("AIM_LEFT... [ strength: {}] ", value.strength);
+        }
+        if value.action() == Some(Action::AimRight) {
+            println!("AIM_RIGHT... [ strength: {}] ", value.strength);
+        }
+    }
+}

--- a/src/action.rs
+++ b/src/action.rs
@@ -7,24 +7,22 @@ impl Kurinji {
     pub fn get_action_strength<'a, T: Into<&'a str>>(&self, action: T) -> f32 {
         let action = action.into();
         match self.action_raw_strength.get(action) {
-            Some(raw_strength) => {
-                match self.action_deadzone.get(action) {
-                    Some(d) => {
-                        let strength =
-                            Kurinji::get_strength_after_applying_deadzone(
-                                *d,
-                                *raw_strength,
-                            );
-                        if let Some(curve_func) =
-                            self.action_strength_curve.get(action)
-                        {
-                            return curve_func(strength);
-                        }
-                        strength
+            Some(raw_strength) => match self.action_deadzone.get(action) {
+                Some(d) => {
+                    let strength =
+                        Kurinji::get_strength_after_applying_deadzone(
+                            *d,
+                            *raw_strength,
+                        );
+                    if let Some(curve_func) =
+                        self.action_strength_curve.get(action)
+                    {
+                        return curve_func(strength);
                     }
-                    None => *raw_strength,
+                    strength
                 }
-            }
+                None => *raw_strength,
+            },
             None => 0.,
         }
     }
@@ -46,8 +44,13 @@ impl Kurinji {
     ///
     /// Note* meaningful only for analog inputs like joystick,
     /// mouse move delta...etc
-    pub fn set_dead_zone<'a, T: Into<&'a str>>(&mut self, action: T, value: f32) -> &mut Kurinji {
-        self.action_deadzone.insert(action.into().to_string(), value);
+    pub fn set_dead_zone<'a, T: Into<&'a str>>(
+        &mut self,
+        action: T,
+        value: f32,
+    ) -> &mut Kurinji {
+        self.action_deadzone
+            .insert(action.into().to_string(), value);
         self
     }
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -4,10 +4,11 @@ impl Kurinji {
     // publics
     /// Provides strength of action in range 0.0 - 1.0. Useful
     /// when working actions that mapped to analog input eg. joystick
-    pub fn get_action_strength(&self, action: &str) -> f32 {
-        match self.action_raw_strength.get(&action.to_string()) {
+    pub fn get_action_strength<'a, T: Into<&'a str>>(&self, action: T) -> f32 {
+        let action = action.into();
+        match self.action_raw_strength.get(action) {
             Some(raw_strength) => {
-                match self.action_deadzone.get(&action.to_string()) {
+                match self.action_deadzone.get(action) {
                     Some(d) => {
                         let strength =
                             Kurinji::get_strength_after_applying_deadzone(
@@ -15,7 +16,7 @@ impl Kurinji {
                                 *raw_strength,
                             );
                         if let Some(curve_func) =
-                            self.action_strength_curve.get(&action.to_string())
+                            self.action_strength_curve.get(action)
                         {
                             return curve_func(strength);
                         }
@@ -30,7 +31,8 @@ impl Kurinji {
 
     /// Is this action happening.
     /// Note* this depends on action event phase
-    pub fn is_action_active(&self, action: &str) -> bool {
+    pub fn is_action_active<'a, T: Into<&'a str>>(&self, action: T) -> bool {
+        let action = action.into();
         match self.get_event_phase(action) {
             EventPhase::OnBegin => self.did_action_just_began(action),
             EventPhase::OnProgress => self.is_action_in_progress(action),
@@ -44,20 +46,20 @@ impl Kurinji {
     ///
     /// Note* meaningful only for analog inputs like joystick,
     /// mouse move delta...etc
-    pub fn set_dead_zone(&mut self, action: &str, value: f32) -> &mut Kurinji {
-        self.action_deadzone.insert(action.to_string(), value);
+    pub fn set_dead_zone<'a, T: Into<&'a str>>(&mut self, action: T, value: f32) -> &mut Kurinji {
+        self.action_deadzone.insert(action.into().to_string(), value);
         self
     }
 
     /// Set a custom curve function that will be applied to
     /// actions strength.
-    pub fn set_strength_curve_function(
+    pub fn set_strength_curve_function<'a, T: Into<&'a str>>(
         &mut self,
-        action: &str,
+        action: T,
         function: fn(f32) -> f32,
     ) -> &mut Kurinji {
         self.action_strength_curve
-            .insert(action.to_string(), function);
+            .insert(action.into().to_string(), function);
         self
     }
 
@@ -87,7 +89,7 @@ impl Kurinji {
         // cache prev frame
         input_map.action_prev_strength.clear();
         for k in input_map.action_raw_strength.clone().keys() {
-            let strength = input_map.get_action_strength(&k);
+            let strength = input_map.get_action_strength(k.as_str());
             input_map.action_prev_strength.insert(k.clone(), strength);
         }
         input_map.reset_all_raw_strength();

--- a/src/action_event.rs
+++ b/src/action_event.rs
@@ -1,5 +1,4 @@
 use std::str::FromStr;
-
 use crate::Kurinji;
 use bevy::app::Events;
 use bevy::ecs::{Res, ResMut};
@@ -27,20 +26,26 @@ pub struct OnActionProgress {
 pub struct OnActionEnd {
     pub action: String,
 }
-
 impl OnActionActive {
-    pub fn action<T: FromStr>(&self) -> Option<T> { T::from_str(&self.action).ok() }
+    pub fn action<T: FromStr>(&self) -> Option<T> {
+        T::from_str(&self.action).ok()
+    }
 }
 impl OnActionBegin {
-    pub fn action<T: FromStr>(&self) -> Option<T> { T::from_str(&self.action).ok() }
+    pub fn action<T: FromStr>(&self) -> Option<T> {
+        T::from_str(&self.action).ok()
+    }
 }
 impl OnActionProgress {
-    pub fn action<T: FromStr>(&self) -> Option<T> { T::from_str(&self.action).ok() }
+    pub fn action<T: FromStr>(&self) -> Option<T> {
+        T::from_str(&self.action).ok()
+    }
 }
 impl OnActionEnd {
-    pub fn action<T: FromStr>(&self) -> Option<T> { T::from_str(&self.action).ok() }
+    pub fn action<T: FromStr>(&self) -> Option<T> {
+        T::from_str(&self.action).ok()
+    }
 }
-
 impl Kurinji {
     pub(crate) fn action_event_producer(
         input_map: Res<Kurinji>,

--- a/src/action_event.rs
+++ b/src/action_event.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::Kurinji;
 use bevy::app::Events;
 use bevy::ecs::{Res, ResMut};
@@ -25,6 +27,20 @@ pub struct OnActionProgress {
 pub struct OnActionEnd {
     pub action: String,
 }
+
+impl OnActionActive {
+    pub fn action<T: FromStr>(&self) -> Option<T> { T::from_str(&self.action).ok() }
+}
+impl OnActionBegin {
+    pub fn action<T: FromStr>(&self) -> Option<T> { T::from_str(&self.action).ok() }
+}
+impl OnActionProgress {
+    pub fn action<T: FromStr>(&self) -> Option<T> { T::from_str(&self.action).ok() }
+}
+impl OnActionEnd {
+    pub fn action<T: FromStr>(&self) -> Option<T> { T::from_str(&self.action).ok() }
+}
+
 impl Kurinji {
     pub(crate) fn action_event_producer(
         input_map: Res<Kurinji>,
@@ -42,7 +58,7 @@ impl Kurinji {
             }
         }
         for (action, strength) in _actions {
-            if input_map.is_action_active(&action) {
+            if input_map.is_action_active(action.as_str()) {
                 on_active_event.send(OnActionActive {
                     action: action.clone(),
                     strength,

--- a/src/event_phase.rs
+++ b/src/event_phase.rs
@@ -26,8 +26,8 @@ impl Default for EventPhase {
 impl Kurinji {
     // publics
     /// Returns in which event phase this action active will be true
-    pub fn get_event_phase(&self, action: &str) -> &EventPhase {
-        if let Some(v) = self.action_phase.get(action) {
+    pub fn get_event_phase<'a, T: Into<&'a str>>(&self, action: T) -> &EventPhase {
+        if let Some(v) = self.action_phase.get(action.into()) {
             return v;
         }
         &EventPhase::OnProgress
@@ -35,17 +35,18 @@ impl Kurinji {
 
     /// Set on which event phase should action will be true.
     /// By default will be Phase::OnProgress
-    pub fn set_event_phase(
+    pub fn set_event_phase<'a, T: Into<&'a str>>(
         &mut self,
-        action: &str,
+        action: T,
         phase: EventPhase,
     ) -> &mut Kurinji {
-        self.action_phase.insert(action.to_string(), phase);
+        self.action_phase.insert(action.into().to_string(), phase);
         self
     }
 
     // crates
     pub(crate) fn did_action_just_began(&self, action: &str) -> bool {
+        let action = action.into();
         self.get_prev_strength(action) == 0.0
             && self.get_action_strength(action) > 0.0
     }
@@ -58,6 +59,7 @@ impl Kurinji {
     }
 
     pub(crate) fn did_action_just_end(&self, action: &str) -> bool {
+        let action = action.into();
         self.get_prev_strength(action) > 0.0
             && self.get_action_strength(action) == 0.0
     }

--- a/src/event_phase.rs
+++ b/src/event_phase.rs
@@ -26,7 +26,10 @@ impl Default for EventPhase {
 impl Kurinji {
     // publics
     /// Returns in which event phase this action active will be true
-    pub fn get_event_phase<'a, T: Into<&'a str>>(&self, action: T) -> &EventPhase {
+    pub fn get_event_phase<'a, T: Into<&'a str>>(
+        &self,
+        action: T,
+    ) -> &EventPhase {
         if let Some(v) = self.action_phase.get(action.into()) {
             return v;
         }

--- a/src/event_phase.rs
+++ b/src/event_phase.rs
@@ -49,7 +49,6 @@ impl Kurinji {
 
     // crates
     pub(crate) fn did_action_just_began(&self, action: &str) -> bool {
-        let action = action.into();
         self.get_prev_strength(action) == 0.0
             && self.get_action_strength(action) > 0.0
     }
@@ -62,7 +61,6 @@ impl Kurinji {
     }
 
     pub(crate) fn did_action_just_end(&self, action: &str) -> bool {
-        let action = action.into();
         self.get_prev_strength(action) > 0.0
             && self.get_action_strength(action) == 0.0
     }

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -10,24 +10,24 @@ pub struct GamepadState {
 impl Kurinji {
     // publics
     // buttons
-    pub fn bind_gamepad_button_pressed(
+    pub fn bind_gamepad_button_pressed<'a, T: Into<&'a str>>(
         &mut self,
         pad_button: GamepadButtonType,
-        action: &str,
+        action: T,
     ) -> &mut Kurinji {
         self.bind_gamepad_button_pressed_for_player(0, pad_button, action)
     }
 
-    pub fn bind_gamepad_button_pressed_for_player(
+    pub fn bind_gamepad_button_pressed_for_player<'a, T: Into<&'a str>>(
         &mut self,
         player: usize,
         pad_button: GamepadButtonType,
-        action: &str,
+        action: T,
     ) -> &mut Kurinji {
         *self
             .joystick_button_binding
             .entry((player, pad_button))
-            .or_default() = action.to_string();
+            .or_default() = action.into().to_string();
         self
     }
 
@@ -48,24 +48,24 @@ impl Kurinji {
     }
 
     // axis
-    pub fn bind_gamepad_axis(
+    pub fn bind_gamepad_axis<'a, T: Into<&'a str>>(
         &mut self,
         axis: GamepadAxis,
-        action: &str,
+        action: T,
     ) -> &mut Kurinji {
         self.bind_gamepad_axis_for_player(0, axis, action)
     }
 
-    pub fn bind_gamepad_axis_for_player(
+    pub fn bind_gamepad_axis_for_player<'a, T: Into<&'a str>>(
         &mut self,
         player: usize,
         axis: GamepadAxis,
-        action: &str,
+        action: T,
     ) -> &mut Kurinji {
         *self
             .joystick_axis_binding
             .entry((player, axis))
-            .or_default() = action.to_string();
+            .or_default() = action.into().to_string();
         self
     }
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -4,13 +4,13 @@ use bevy::ecs::{Res, ResMut};
 use bevy::input::Input;
 impl Kurinji {
     // publics
-    pub fn bind_keyboard_pressed(
+    pub fn bind_keyboard_pressed<'a, T: Into<&'a str>>(
         &mut self,
         code: KeyCode,
-        action: &str,
+        action: T,
     ) -> &mut Kurinji {
         self.keyboard_action_binding
-            .insert(code, action.to_string());
+            .insert(code, action.into().to_string());
         self
     }
 

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -14,7 +14,8 @@ impl Kurinji {
         code: MouseButton,
         action: T,
     ) -> &mut Kurinji {
-        self.mouse_button_binding.insert(code, action.into().to_string());
+        self.mouse_button_binding
+            .insert(code, action.into().to_string());
         self
     }
 
@@ -31,7 +32,8 @@ impl Kurinji {
         axis: MouseAxis,
         action: T,
     ) -> &mut Kurinji {
-        self.mouse_move_binding.insert(axis, action.into().to_string());
+        self.mouse_move_binding
+            .insert(axis, action.into().to_string());
         self
     }
 

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -9,12 +9,12 @@ pub struct MouseMoveState {
 }
 impl Kurinji {
     // publics
-    pub fn bind_mouse_button_pressed(
+    pub fn bind_mouse_button_pressed<'a, T: Into<&'a str>>(
         &mut self,
         code: MouseButton,
-        action: &str,
+        action: T,
     ) -> &mut Kurinji {
-        self.mouse_button_binding.insert(code, action.to_string());
+        self.mouse_button_binding.insert(code, action.into().to_string());
         self
     }
 
@@ -26,12 +26,12 @@ impl Kurinji {
         self
     }
 
-    pub fn bind_mouse_motion(
+    pub fn bind_mouse_motion<'a, T: Into<&'a str>>(
         &mut self,
         axis: MouseAxis,
-        action: &str,
+        action: T,
     ) -> &mut Kurinji {
-        self.mouse_move_binding.insert(axis, action.to_string());
+        self.mouse_move_binding.insert(axis, action.into().to_string());
         self
     }
 


### PR DESCRIPTION
This adds support for enums or structs that implement `FromStr` and `Into<&str>`. This does not break APIs, but makes function inputs more flexible and adds a helper function. So example/enum.rs is just added and other examples have no changes.
Thanks